### PR TITLE
Improve parser by allowing case insensitive command lines and updating the output dictionary to records

### DIFF
--- a/KakaoChatParser/Extensions.cs
+++ b/KakaoChatParser/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using CsvHelper;
+using KakaoChatParser.Formats;
 using System.Globalization;
 using System.Text;
 
@@ -32,14 +33,14 @@ namespace KakaoChatParser
         /// </summary>
         /// <typeparam name="TKey">The key.</typeparam>
         /// <typeparam name="TValue">The value.</typeparam>
-        /// <param name="dictionary">The <see cref="IDictionary{TKey, TValue}"/>.</param>
+        /// <param name="output">The <see cref="IEnumerable<Output>"/>.</param>
         /// <param name="outputPath">The output path.</param>
-        internal static void WriteToCSV<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, string outputPath)
+        internal static void WriteToCSV(this IEnumerable<Output> output, string outputPath)
         {
             using (var writer = new StreamWriter(outputPath, false, Encoding.UTF8))
             using (var csv = new CsvWriter(writer, CultureInfo.InvariantCulture))
             {
-                csv.WriteRecords(dictionary);
+                csv.WriteRecords(output);
             }
         }
     }

--- a/KakaoChatParser/Formats/Output.cs
+++ b/KakaoChatParser/Formats/Output.cs
@@ -1,0 +1,9 @@
+﻿namespace KakaoChatParser.Formats
+{
+    /// <summary>
+    /// The output format of the csv.
+    /// </summary>
+    /// <param name="Nickname">The nickname.</param>
+    /// <param name="ChatCount">The chat count.</param>
+    internal record Output(string Nickname, int ChatCount);
+}

--- a/KakaoChatParser/Program.cs
+++ b/KakaoChatParser/Program.cs
@@ -14,7 +14,8 @@ public class Program
     /// <exception cref="ArgumentException">When the parser fails to parse arguments.</exception>
     public static void Main(string[] args)
     {
-        Parser.Default.ParseArguments<Options>(args)
+        var parser = new Parser(settings => settings.CaseSensitive = false);
+        parser.ParseArguments<Options>(args)
             .WithParsed(Run)
             .WithNotParsed(e => throw new ArgumentException());
     }

--- a/KakaoChatParser/Runner.cs
+++ b/KakaoChatParser/Runner.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using KakaoChatParser.Formats;
+using System.Text.RegularExpressions;
 
 namespace KakaoChatParser
 {
@@ -78,9 +79,13 @@ namespace KakaoChatParser
                 }
             }
 
-            var sortedDict = dictionary.OrderByDescending(x => x.Value).ToDictionary(x => x.Key, x => x.Value);
             var outputPath = Path.Combine(options.OutputPath, OutputFileName);
-            sortedDict.WriteToCSV(outputPath);
+
+            var outputs = new List<Output>();
+            outputs.AddRange(dictionary.Select(x => new Output(x.Key, x.Value)));
+
+            var orderedOutputs = outputs.OrderByDescending(x => x.ChatCount);
+            orderedOutputs.WriteToCSV(outputPath);
 
             Console.WriteLine($"Ran the program and saved the final output to: {outputPath}");
         }


### PR DESCRIPTION
Improve parser by allowing case insensitive command lines and updating the output dictionary to records.
With the change, `--filePath` or `--filepath` will both work for command lines for example, and the output CSV will have a proper header.